### PR TITLE
Refactor Cashier Session Management and Update Summary Details

### DIFF
--- a/app/Http/Controllers/CashierSessionController.php
+++ b/app/Http/Controllers/CashierSessionController.php
@@ -139,10 +139,15 @@ class CashierSessionController extends Controller
 
     public function getSessionSummary(Request $request)
     {
-        $openSession = $this->cashierSessionService->model->openSession()->with('cashier')->first();
+        $session = $this->cashierSessionService->model->openSession()->with('cashier')->first();
 
-        if ($openSession) {
-            $sessionSummary = $this->cashierSessionService->getSessionSummary($openSession);
+        if (! $session) {
+            // If no open session, get the latest session (just closed)
+            $session = $this->cashierSessionService->model->where('cashier_id', Auth::id())->latest()->first();
+        }
+
+        if ($session) {
+            $sessionSummary = $this->cashierSessionService->getSessionSummary($session);
             return response()->json($sessionSummary);
         }
 

--- a/app/Http/Requests/CashierSessionRequest.php
+++ b/app/Http/Requests/CashierSessionRequest.php
@@ -21,10 +21,10 @@ class CashierSessionRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'beginning_cash'    => 'sometimes|required|numeric|min:0',
-            'cash_denomination' => 'sometimes|required|array',
-            'closing_cash'      => 'sometimes|required|numeric|min:0',
-            'table_id'          => 'sometimes|nullable|exists:table_rooms,id',
+            'beginning_cash'            => 'sometimes|required|numeric|min:0',
+            'cash_denomination_details' => 'sometimes|required|array',
+            'closing_cash'              => 'sometimes|required|numeric|min:0',
+            'table_id'                  => 'sometimes|nullable|exists:table_rooms,id',
         ];
     }
 }

--- a/app/Models/CashierSession.php
+++ b/app/Models/CashierSession.php
@@ -18,23 +18,24 @@ class CashierSession extends Model
         'closing_cash',
         'total_sales',
         'check_by',
+        'cash_denomination_details',
         'cash_denomination',
         'meta_data',
         'notes',
     ];
 
     protected $casts = [
-        'business_date'     => 'datetime',
-        'started_time'      => 'datetime',
-        'closing_time'      => 'datetime',
-        'cash_denomination' => 'array',
-        'meta_data'         => 'array',
+        'business_date'             => 'datetime',
+        'started_time'              => 'datetime',
+        'closing_time'              => 'datetime',
+        'cash_denomination_details' => 'array',
+        'meta_data'                 => 'array',
     ];
 
     public function scopeOpenSession(Builder $query): void
     {
         $query->where('cashier_id', Auth::id())
-            // ->where('branch_id', session('active_branch')['id'])
+        // ->where('branch_id', session('active_branch')['id'])
             ->whereNull('closing_time');
     }
 

--- a/app/Services/CashierSessionService.php
+++ b/app/Services/CashierSessionService.php
@@ -56,18 +56,19 @@ class CashierSessionService
 
     public function closeSession(Request $request)
     {
-        $session = $this->model
-            ->openSession()
-            ->first();
+        $session = $this->model->openSession()->first();
 
         if (! $session) {
             throw new Exception('No open session found');
         }
 
+        $cashDenomination = $session->beginning_cash - $request->closing_cash;
+
         $closeSession = $session->update([
-            'closing_time'      => now(),
-            'closing_cash'      => $request->closing_cash,
-            'cash_denomination' => $request->cash_denomination,
+            'closing_time'              => now(),
+            'closing_cash'              => $request->closing_cash,
+            'cash_denomination_details' => $request->cash_denomination_details,
+            'cash_denomination'         => $cashDenomination,
         ]);
 
         return $closeSession;
@@ -250,6 +251,7 @@ class CashierSessionService
         $totalSales           = 0;
         $itemsSettled         = 0;
         $guestsServed         = 0;
+        $grossSales           = 0;
         $netSales             = 0;
         $totalLessTax         = 0;
         $transactionsCount    = $orders->count();
@@ -270,7 +272,8 @@ class CashierSessionService
             $vatableSales += $order->orderItems->sum('vatable_sales');
             $nonVatableSales += $order->orderItems->sum('non_vat_sales');
             $vatAmount += $order->orderItems->sum('vat_amount');
-            $netSales += $order->orderItems->sum('amount');
+            $grossSales += $order->orderItems->sum('amount');
+            $netSales += $order->orderItems->sum('sub_total');
 
             $seniorDiscountTotal += $seniorDiscount ? $order->orderItems
                 ->where('discount_id', $seniorDiscount->id)
@@ -303,32 +306,35 @@ class CashierSessionService
         }
 
         return [
-            'orders'             => $orderSummaries,
-            'total_sales'        => $totalSales,
-            'gross_sales'        => $totalSales,
-            'net_sales'          => $netSales,
-            'items_settled'      => $itemsSettled,
-            'guests_served'      => $guestsServed,
-            'transactions_count' => $transactionsCount,
-            'sku_count'          => $itemsSettled,
-            'total_quantity'     => $totalQuantity,
-            'cancelled_amount'   => $cancelledAmount,
-            'regular_discount'   => $regularDiscountTotal,
-            'senior_discount'    => $seniorDiscountTotal,
-            'pwd_discount'       => $pwdDiscountTotal,
-            'non_vat_sales'      => $nonVatableSales,
-            'vat_sales'          => $vatableSales,
-            'vat_amount'         => $vatAmount,
-            'less_tax'           => $totalLessTax,
-            'previous_reading'   => 0,
-            'running_total'      => $totalSales,
-            'session_number'     => str_pad($session->id, 4, '0', STR_PAD_LEFT),
-            'expected_cash'      => $session->beginning_cash ?? 0,
-            'cash_denomination'  => $session->closing_cash ?? 0,
-            'or_number_start'    => $orders->first()->invoice_no ?? null,
-            'or_number_end'      => $orders->last()->invoice_no ?? null,
-            'bill_number_start'  => $orders->first()->bill_no ?? null,
-            'bill_number_end'    => $orders->last()->bill_no ?? null,
+            'orders'                    => $orderSummaries,
+            'total_sales'               => $totalSales,
+            'gross_sales'               => $grossSales,
+            'net_sales'                 => $netSales,
+            'items_settled'             => $itemsSettled,
+            'guests_served'             => $guestsServed,
+            'transactions_count'        => $transactionsCount,
+            'sku_count'                 => $itemsSettled,
+            'total_quantity'            => $totalQuantity,
+            'cancelled_amount'          => $cancelledAmount,
+            'regular_discount'          => $regularDiscountTotal,
+            'senior_discount'           => $seniorDiscountTotal,
+            'pwd_discount'              => $pwdDiscountTotal,
+            'non_vat_sales'             => $nonVatableSales,
+            'vat_sales'                 => $vatableSales,
+            'vat_amount'                => $vatAmount,
+            'less_tax'                  => $totalLessTax,
+            'previous_reading'          => 0,
+            'running_total'             => $totalSales,
+            'session_number'            => str_pad($session->id, 4, '0', STR_PAD_LEFT),
+            'beginning_cash'            => $session->beginning_cash ?? 0,
+            'closing_cash'              => $session->closing_cash ?? 0,
+            'expected_cash'             => ($session->beginning_cash ?? 0) + $totalSales,
+            'cash_denomination'         => $session->cash_denomination,
+            'cash_denomination_details' => $session->cash_denomination_details,
+            'or_number_start'           => $orders->first()->invoice_no ?? null,
+            'or_number_end'             => $orders->last()->invoice_no ?? null,
+            'bill_number_start'         => $orders->first()->bill_no ?? null,
+            'bill_number_end'           => $orders->last()->bill_no ?? null,
         ];
     }
 }

--- a/database/migrations/tenant/2025_12_05_015634_update_column_in_cashier_sessions_table.php
+++ b/database/migrations/tenant/2025_12_05_015634_update_column_in_cashier_sessions_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('cashier_sessions', function (Blueprint $table) {
+            $table->renameColumn('cash_denomination', 'cash_denomination_details');
+            $table->integer('cash_denomination')->after('closing_cash')->nullable()->default(0);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('cashier_sessions', function (Blueprint $table) {
+            $table->dropColumn('cash_denomination');
+            $table->renameColumn('cash_denomination_details', 'cash_denomination');
+        });
+    }
+};

--- a/resources/js/Pages/Resto/Partials/CloseSessionModal.vue
+++ b/resources/js/Pages/Resto/Partials/CloseSessionModal.vue
@@ -27,24 +27,6 @@
                             }}
                         </p>
                     </div>
-                    <div>
-                        <p class="text-sm text-gray-600">Total Sales</p>
-                        <p class="text-xl font-bold text-green-600">
-                            {{
-                                formatMoney(
-                                    (
-                                        props.openSession?.total_sales || 0
-                                    ).toFixed(2)
-                                )
-                            }}
-                        </p>
-                    </div>
-                    <div class="col-span-2 border-t pt-4">
-                        <p class="text-sm text-gray-600">Expected Cash</p>
-                        <p class="text-2xl font-bold text-blue-600">
-                            {{ formatMoney(expectedCash.toFixed(2)) }}
-                        </p>
-                    </div>
                 </div>
             </div>
 
@@ -53,21 +35,32 @@
                 <h4 class="text-lg font-semibold text-gray-900 mb-4">
                     Cash Count
                 </h4>
-                <div class="grid grid-cols-2 md:grid-cols-3 gap-4">
+                <div class="grid grid-cols-1 md:grid-cols-1 gap-4">
                     <div
-                        v-for="(count, denom) in cashDenominations"
+                        class="grid grid-cols-3 gap-2 font-semibold text-sm mb-2 text-center"
+                    >
+                        <span>Quantity</span>
+                        <span>Money Value</span>
+                        <span>Total</span>
+                    </div>
+                    <div
+                        v-for="[denom, count] in Object.entries(
+                            cashDenominations
+                        ).sort(([a], [b]) => parseFloat(b) - parseFloat(a))"
                         :key="denom"
-                        class="space-y-2"
+                        class="grid grid-cols-3 gap-2 items-center"
                     >
                         <TextField
-                            :label="`${formatMoney(denom)}`"
                             v-model.number="cashDenominations[denom]"
                             type="number"
                             min="0"
                             :placeholder="`Count of ₱${denom}`"
+                            class="w-full"
                         />
-                        <p class="text-xs text-gray-500">
-                            Total:
+                        <p class="text-sm text-gray-900 text-center">
+                            {{ formatMoney(denom) }}
+                        </p>
+                        <p class="text-sm text-gray-900 text-center">
                             {{
                                 formatMoney(
                                     (parseFloat(denom) * count).toFixed(2)
@@ -107,17 +100,6 @@
             </div>
         </template>
     </Dialog>
-
-    <SessionSummaryModal
-        :showSessionSummaryModal="showSessionSummaryModal"
-        :openSession="openSession"
-        :sessionSummary="sessionSummaryData"
-        :currentUser="currentUser"
-        :totalCashCounted="totalCashCounted"
-        :general-settings="props.generalSettings"
-        @closeModal="showSessionSummaryModal = false"
-        @confirmClose="handleFinalConfirm"
-    />
 </template>
 
 <script setup lang="ts">
@@ -126,9 +108,6 @@ import CashieringSession from "@/Types/CashieringSession";
 import { formatMoney } from "@/Utils/FormatMoney";
 import { Button, Dialog } from "primevue";
 import { computed, ref } from "vue";
-import SessionSummaryModal from "./SessionSummaryModal.vue";
-import axios from "axios";
-import { route } from "ziggy-js";
 import { useToast } from "primevue";
 
 const props = defineProps<{
@@ -139,11 +118,13 @@ const props = defineProps<{
     generalSettings: any;
 }>();
 
-const emit = defineEmits(["confirmCloseSession", "closeModal", "sessionClosed"]);
+const emit = defineEmits([
+    "confirmCloseSession",
+    "closeModal",
+    "sessionClosed",
+]);
 
 const toast = useToast();
-const showSessionSummaryModal = ref(false);
-const sessionSummaryData = ref(null);
 
 const expectedCash = computed(() => {
     if (!props.openSession) return 0;
@@ -154,16 +135,17 @@ const expectedCash = computed(() => {
 });
 
 const cashDenominations = ref({
-    "0.25": 0,
-    "1": 0,
-    "5": 0,
-    "10": 0,
-    "20": 0,
-    "50": 0,
-    "100": 0,
-    "200": 0,
-    "500": 0,
     "1000": 0,
+    "500": 0,
+    "200": 0,
+    "100": 0,
+    "50": 0,
+    "20": 0,
+    "10": 0,
+    "5": 0,
+    "1": 0,
+    "0.25": 0,
+    "0.5": 0,
 });
 
 const totalCashCounted = computed(() => {
@@ -178,17 +160,7 @@ const cashDifference = computed(() => {
     return totalCashCounted.value - expectedCash.value;
 });
 
-const handleConfirmCloseSession = async () => {
-    try {
-        const response = await axios.get(route("resto.api.session-summary"));
-        sessionSummaryData.value = response.data;
-        showSessionSummaryModal.value = true;
-    } catch (error) {
-        console.error("Failed to fetch session summary", error);
-    }
-};
-
-const handleFinalConfirm = () => {
+const handleConfirmCloseSession = () => {
     const denominationData = Object.entries(cashDenominations.value).reduce(
         (acc, [denom, count]) => {
             if (count > 0) {
@@ -203,7 +175,6 @@ const handleFinalConfirm = () => {
         denominationData: denominationData,
         totalCashCounted: totalCashCounted.value,
     });
-    showSessionSummaryModal.value = false;
 };
 
 const handleClose = () => {

--- a/resources/js/Pages/Resto/Partials/SessionSummaryModal.vue
+++ b/resources/js/Pages/Resto/Partials/SessionSummaryModal.vue
@@ -53,29 +53,6 @@
 
             <div class="text-left text-xs">
                 <div class="flex justify-between">
-                    <span>Session Number:</span>
-                    <span>{{ props.sessionSummary?.session_number }}</span>
-                </div>
-                <div class="flex justify-between">
-                    <span>OR Number Start:</span>
-                    <span>{{ props.sessionSummary?.or_number_start }}</span>
-                </div>
-                <div class="flex justify-between">
-                    <span>OR Number End:</span>
-                    <span>{{ props.sessionSummary?.or_number_end }}</span>
-                </div>
-                <div class="flex justify-between">
-                    <span>Bill Number Start:</span>
-                    <span>{{ props.sessionSummary?.bill_number_start }}</span>
-                </div>
-                <div class="flex justify-between">
-                    <span>Bill Number End:</span>
-                    <span>{{ props.sessionSummary?.bill_number_end }}</span>
-                </div>
-            </div>
-
-            <div class="text-left text-xs">
-                <div class="flex justify-between">
                     <span>Gross Sales:</span>
                     <span>{{ formatMoney(grossSales) }}</span>
                 </div>
@@ -93,6 +70,12 @@
                     <span>PWD Discount:</span>
                     <span>{{ formatMoney(pwdDiscount) }}</span>
                 </div>
+                <div class="flex justify-between">
+                    <span>Less Tax:</span>
+                    <span>
+                        {{ formatMoney(props.sessionSummary?.less_tax || 0) }}
+                    </span>
+                </div>
                 <div class="flex justify-between font-bold border-t pt-1 mt-1">
                     <span>Net Sales:</span>
                     <span>
@@ -102,15 +85,15 @@
 
                 <div class="mt-2"></div>
                 <div class="flex justify-between">
-                    <span>Non-VAT Sales:</span>
-                    <span>
-                        {{ formatMoney(props.sessionSummary?.non_vat_sales) }}
-                    </span>
-                </div>
-                <div class="flex justify-between">
                     <span>VAT Sales:</span>
                     <span>
                         {{ formatMoney(props.sessionSummary?.vat_sales) }}
+                    </span>
+                </div>
+                <div class="flex justify-between">
+                    <span>Non-VAT Sales:</span>
+                    <span>
+                        {{ formatMoney(props.sessionSummary?.non_vat_sales) }}
                     </span>
                 </div>
                 <div class="flex justify-between">
@@ -119,11 +102,32 @@
                         {{ formatMoney(props.sessionSummary?.vat_amount) }}
                     </span>
                 </div>
-                <div class="flex justify-between">
-                    <span>Less Tax:</span>
-                    <span>
-                        {{ formatMoney(props.sessionSummary?.less_tax || 0) }}
-                    </span>
+
+                <div class="border-t my-2"></div>
+
+                <div class="text-left text-xs">
+                    <div class="flex justify-between">
+                        <span>Session Number:</span>
+                        <span>{{ props.sessionSummary?.session_number }}</span>
+                    </div>
+                    <div class="flex justify-between">
+                        <span>OR Number Start:</span>
+                        <span>{{ props.sessionSummary?.or_number_start }}</span>
+                    </div>
+                    <div class="flex justify-between">
+                        <span>OR Number End:</span>
+                        <span>{{ props.sessionSummary?.or_number_end }}</span>
+                    </div>
+                    <div class="flex justify-between">
+                        <span>Bill Number Start:</span>
+                        <span>{{
+                            props.sessionSummary?.bill_number_start
+                        }}</span>
+                    </div>
+                    <div class="flex justify-between">
+                        <span>Bill Number End:</span>
+                        <span>{{ props.sessionSummary?.bill_number_end }}</span>
+                    </div>
                 </div>
 
                 <div class="border-t my-2"></div>
@@ -195,12 +199,21 @@
                 <div class="border-t my-2"></div>
 
                 <div class="flex justify-between">
-                    <span>Expected Cash:</span>
+                    <span>Beginning Cash:</span>
                     <span>
                         {{
                             formatMoney(
-                                props.sessionSummary?.expected_cash || 0
+                                props.sessionSummary?.beginning_cash || 0
                             )
+                        }}
+                    </span>
+                </div>
+
+                <div class="flex justify-between">
+                    <span>Closing Cash:</span>
+                    <span>
+                        {{
+                            formatMoney(props.sessionSummary?.closing_cash || 0)
                         }}
                     </span>
                 </div>
@@ -214,6 +227,28 @@
                             )
                         }}
                     </span>
+                </div>
+
+                <!-- Cash Denomination Details -->
+                <div
+                    v-if="props.sessionSummary?.cash_denomination_details"
+                    class="mt-2"
+                >
+                    <div class="text-xs font-semibold mb-1">
+                        Cash Breakdown:
+                    </div>
+                    <div
+                        v-for="[denom, count] in Object.entries(
+                            props.sessionSummary.cash_denomination_details
+                        )"
+                        :key="denom"
+                        class="flex justify-between text-xs ml-2"
+                    >
+                        <span>{{ formatMoney(denom) }} x {{ count }}:</span>
+                        <span>
+                            {{ formatMoney(parseFloat(denom) * Number(count)) }}
+                        </span>
+                    </div>
                 </div>
 
                 <div class="border-t my-2"></div>

--- a/resources/js/Pages/Resto/Preview.vue
+++ b/resources/js/Pages/Resto/Preview.vue
@@ -106,6 +106,18 @@
             :open-session="props.openSession"
             :general-settings="props.generalSettings"
             @close-modal="showCloseDialog = false"
+            @confirm-close-session="confirmCloseSession"
+        />
+
+        <!-- Session Summary Modal -->
+        <SessionSummaryModal
+            :show-session-summary-modal="showSessionSummaryModal"
+            :open-session="props.openSession"
+            :session-summary="sessionSummaryData"
+            :current-user="page.props.auth.user"
+            :general-settings="props.generalSettings"
+            @close-modal="showSessionSummaryModal = false"
+            @confirm-close="showSessionSummaryModal = false"
         />
     </HomeLayout>
 </template>
@@ -114,6 +126,7 @@
 import { ref } from "vue";
 import { route } from "ziggy-js";
 import { router } from "@inertiajs/vue3";
+import axios from "axios";
 import CashieringSession from "@/Types/CashieringSession";
 import Branch from "@/Types/Branch";
 import { usePage } from "@inertiajs/vue3";
@@ -122,6 +135,7 @@ import { useConfirm, useToast } from "primevue";
 import PageProps from "@/Types/PageProps";
 import HomeLayout from "@/Layouts/HomeLayout.vue";
 import CloseSessionModal from "./Partials/CloseSessionModal.vue";
+import SessionSummaryModal from "./Partials/SessionSummaryModal.vue";
 
 const props = defineProps<{
     activeBranch: Branch;
@@ -135,6 +149,8 @@ const toast = useToast();
 
 const beginningCash = ref("");
 const showCloseDialog = ref(false);
+const showSessionSummaryModal = ref(false);
+const sessionSummaryData = ref(null);
 
 const continueSession = () => {
     router.visit(route("resto.index"));
@@ -145,16 +161,26 @@ const confirmCloseSessionModal = (event: any) => {
 };
 
 const confirmCloseSession = (data: any) => {
-    console.log(data);
     router.post(
         route("resto.session.close"),
         {
-            cash_denomination: data.denominationData,
+            cash_denomination_details: data.denominationData,
             closing_cash: data.totalCashCounted,
         },
         {
             onSuccess: () => {
                 showCloseDialog.value = false;
+                // Fetch session summary after successful close
+                axios
+                    .get(route("resto.api.session-summary"))
+                    .then((response) => {
+                        sessionSummaryData.value = response.data;
+                        showSessionSummaryModal.value = true;
+                    })
+                    .catch((error) => {
+                        console.error("Failed to fetch session summary", error);
+                    });
+
                 toast.add({
                     severity: "success",
                     summary: "Success",
@@ -176,7 +202,12 @@ const confirmCloseSession = (data: any) => {
 
 const startSession = () => {
     if (!beginningCash.value || parseFloat(beginningCash.value) < 0) {
-        alert("Please enter a valid beginning cash amount");
+        toast.add({
+            severity: "error",
+            summary: "Error",
+            detail: "Please enter a valid beginning cash amount",
+            life: 3000,
+        });
         return;
     }
 
@@ -188,14 +219,17 @@ const startSession = () => {
         },
         {
             onSuccess: () => {
-                // Refresh the page to show the new session
-                window.location.reload();
+                //
             },
             onError: (errors) => {
-                alert(
-                    "Failed to start session: " +
-                        (errors.beginning_cash || "Unknown error")
-                );
+                toast.add({
+                    severity: "error",
+                    summary: "Error",
+                    detail:
+                        "Failed to start session: " +
+                        (errors.beginning_cash || "Unknown error"),
+                    life: 3000,
+                });
             },
         }
     );

--- a/resources/js/Services/ThermalPrinterService.ts
+++ b/resources/js/Services/ThermalPrinterService.ts
@@ -104,30 +104,33 @@ interface BluetoothPrintService {
 }
 
 interface SessionSummaryData {
-    session_number: string;
-    or_number: string;
-    bill_number_start: string;
-    bill_number_end: string;
-    gross_sales: number;
-    regular_discount: number;
-    senior_discount: number;
-    pwd_discount: number;
-    net_sales: number;
-    non_vat_sales: number;
-    vat_sales: number;
-    vat_amount: number;
-    less_tax: number;
-    cancelled_count: number;
-    cancelled_amount: number;
-    transactions_count: number;
-    sku_count: number;
-    total_quantity: number;
-    previous_reading: number;
-    running_total: number;
-    expected_cash: number;
-    cash_denomination: number;
-    counter_id_start?: string;
-    counter_id_end?: string;
+    session_number: string | null;
+    or_number_start: string | null;
+    or_number_end: string | null;
+    bill_number_start: string | null;
+    bill_number_end: string | null;
+    gross_sales: number | null;
+    regular_discount: number | null;
+    senior_discount: number | null;
+    pwd_discount: number | null;
+    net_sales: number | null;
+    non_vat_sales: number | null;
+    vat_sales: number | null;
+    vat_amount: number | null;
+    less_tax: number | null;
+    cancelled_count: number | null;
+    cancelled_amount: number | null;
+    transactions_count: number | null;
+    sku_count: number | null;
+    total_quantity: number | null;
+    previous_reading: number | null;
+    running_total: number | null;
+    beginning_cash: number | null;
+    closing_cash: number | null;
+    cash_denomination: number | null;
+    cash_denomination_details?: Record<string, number> | null;
+    counter_id_start?: string | null;
+    counter_id_end?: string | null;
 }
 
 interface PrinterConfig {
@@ -931,7 +934,7 @@ class ThermalPrinterService {
 
                     // Less tax (if any)
                     if (item.less_tax !== undefined && item.less_tax !== null && item.less_tax !== '') {
-                        const lessTaxValue = typeof item.less_tax === 'string' ? parseFloat(item.less_tax) : item.less_tax  ;
+                        const lessTaxValue = typeof item.less_tax === 'string' ? parseFloat(item.less_tax) : item.less_tax;
                         if (lessTaxValue !== 0) {
                             const taxLine = this.formatDeductionLine('Less Tax:', lessTaxValue);
                             commands.push(...this.stringToBytes(`  ${taxLine}`));
@@ -1135,38 +1138,40 @@ class ThermalPrinterService {
             // Left align for details
             commands.push(...this.ESC_POS.ALIGN_LEFT);
 
-            // Session details
-            commands.push(...this.stringToBytes(this.formatInfoLine('Session Number:', sessionSummary.session_number)));
-            commands.push(...this.ESC_POS.LINE_FEED);
-            commands.push(...this.stringToBytes(this.formatInfoLine('OR Number:', sessionSummary.or_number)));
-            commands.push(...this.ESC_POS.LINE_FEED);
-            commands.push(...this.stringToBytes(this.formatInfoLine('Bill Number Start:', sessionSummary.bill_number_start)));
-            commands.push(...this.ESC_POS.LINE_FEED);
-            commands.push(...this.stringToBytes(this.formatInfoLine('Bill Number End:', sessionSummary.bill_number_end)));
-            commands.push(...this.ESC_POS.LINE_FEED, ...this.ESC_POS.LINE_FEED);
-
             // Sales summary
-            commands.push(...this.stringToBytes(this.formatTotalLine('Gross Sales:', sessionSummary.gross_sales)));
+            commands.push(...this.stringToBytes(this.formatTotalLine('Gross Sales:', sessionSummary.gross_sales || 0)));
             commands.push(...this.ESC_POS.LINE_FEED);
-            commands.push(...this.stringToBytes(this.formatTotalLine('Regular Discount:', sessionSummary.regular_discount)));
+            commands.push(...this.stringToBytes(this.formatTotalLine('Regular Discount:', sessionSummary.regular_discount || 0)));
             commands.push(...this.ESC_POS.LINE_FEED);
-            commands.push(...this.stringToBytes(this.formatTotalLine('Senior Discount:', sessionSummary.senior_discount)));
+            commands.push(...this.stringToBytes(this.formatTotalLine('Senior Discount:', sessionSummary.senior_discount || 0)));
             commands.push(...this.ESC_POS.LINE_FEED);
-            commands.push(...this.stringToBytes(this.formatTotalLine('PWD Discount:', sessionSummary.pwd_discount)));
+            commands.push(...this.stringToBytes(this.formatTotalLine('PWD Discount:', sessionSummary.pwd_discount || 0)));
+            commands.push(...this.ESC_POS.LINE_FEED);
+            commands.push(...this.stringToBytes(this.formatTotalLine('Less Tax:', sessionSummary.less_tax || 0)));
             commands.push(...this.ESC_POS.LINE_FEED);
             commands.push(...this.ESC_POS.BOLD_ON);
-            commands.push(...this.stringToBytes(this.formatTotalLine('Net Sales:', sessionSummary.net_sales)));
+            commands.push(...this.stringToBytes(this.formatTotalLine('Net Sales:', sessionSummary.net_sales || 0)));
             commands.push(...this.ESC_POS.BOLD_OFF);
             commands.push(...this.ESC_POS.LINE_FEED, ...this.ESC_POS.LINE_FEED);
 
             // VAT breakdown
-            commands.push(...this.stringToBytes(this.formatTotalLine('Non-VAT Sales:', sessionSummary.non_vat_sales)));
+            commands.push(...this.stringToBytes(this.formatTotalLine('VAT Sales:', sessionSummary.vat_sales || 0)));
             commands.push(...this.ESC_POS.LINE_FEED);
-            commands.push(...this.stringToBytes(this.formatTotalLine('VAT Sales:', sessionSummary.vat_sales)));
+            commands.push(...this.stringToBytes(this.formatTotalLine('Non-VAT Sales:', sessionSummary.non_vat_sales || 0)));
             commands.push(...this.ESC_POS.LINE_FEED);
-            commands.push(...this.stringToBytes(this.formatTotalLine('VAT:', sessionSummary.vat_amount)));
+            commands.push(...this.stringToBytes(this.formatTotalLine('VAT:', sessionSummary.vat_amount || 0)));
+            commands.push(...this.ESC_POS.LINE_FEED, ...this.ESC_POS.LINE_FEED);
+
+            // Session details
+            commands.push(...this.stringToBytes(this.formatInfoLine('Session Number:', sessionSummary.session_number || '')));
             commands.push(...this.ESC_POS.LINE_FEED);
-            commands.push(...this.stringToBytes(this.formatTotalLine('Less Tax:', sessionSummary.less_tax)));
+            commands.push(...this.stringToBytes(this.formatInfoLine('OR Number Start:', sessionSummary.or_number_start || '')));
+            commands.push(...this.ESC_POS.LINE_FEED);
+            commands.push(...this.stringToBytes(this.formatInfoLine('OR Number End:', sessionSummary.or_number_end || '')));
+            commands.push(...this.ESC_POS.LINE_FEED);
+            commands.push(...this.stringToBytes(this.formatInfoLine('Bill Number Start:', sessionSummary.bill_number_start || '')));
+            commands.push(...this.ESC_POS.LINE_FEED);
+            commands.push(...this.stringToBytes(this.formatInfoLine('Bill Number End:', sessionSummary.bill_number_end || '')));
             commands.push(...this.ESC_POS.LINE_FEED, ...this.ESC_POS.LINE_FEED);
 
             // Counter IDs
@@ -1178,34 +1183,50 @@ class ThermalPrinterService {
             }
 
             // Cancellation info
-            commands.push(...this.stringToBytes(this.formatTotalLine('Cancelled Tax:', sessionSummary.cancelled_count)));
-            commands.push(...this.ESC_POS.LINE_FEED);
-            commands.push(...this.stringToBytes(this.formatTotalLine('Cancelled Amount:', sessionSummary.cancelled_amount)));
+            commands.push(...this.stringToBytes(this.formatTotalLine('Cancelled Amount:', sessionSummary.cancelled_amount || 0)));
             commands.push(...this.ESC_POS.LINE_FEED, ...this.ESC_POS.LINE_FEED);
 
             // Transaction summary
-            commands.push(...this.stringToBytes(this.formatTotalLine('No of Transactions:', sessionSummary.transactions_count)));
+            commands.push(...this.stringToBytes(this.formatTotalLine('No of Transactions:', sessionSummary.transactions_count || 0)));
             commands.push(...this.ESC_POS.LINE_FEED);
-            commands.push(...this.stringToBytes(this.formatTotalLine('Number of SKU:', sessionSummary.sku_count)));
+            commands.push(...this.stringToBytes(this.formatTotalLine('Number of SKU:', sessionSummary.sku_count || 0)));
             commands.push(...this.ESC_POS.LINE_FEED);
-            commands.push(...this.stringToBytes(this.formatTotalLine('Total Quantity:', sessionSummary.total_quantity)));
+            commands.push(...this.stringToBytes(this.formatTotalLine('Total Quantity:', sessionSummary.total_quantity || 0)));
             commands.push(...this.ESC_POS.LINE_FEED, ...this.ESC_POS.LINE_FEED);
 
             // Reading summary
-            commands.push(...this.stringToBytes(this.formatTotalLine('Previous Reading:', sessionSummary.previous_reading)));
+            commands.push(...this.stringToBytes(this.formatTotalLine('Previous Reading:', sessionSummary.previous_reading || 0)));
             commands.push(...this.ESC_POS.LINE_FEED);
             commands.push(...this.ESC_POS.BOLD_ON);
-            commands.push(...this.stringToBytes(this.formatTotalLine('Net Sales:', sessionSummary.net_sales)));
+            commands.push(...this.stringToBytes(this.formatTotalLine('Net Sales:', sessionSummary.net_sales || 0)));
             commands.push(...this.ESC_POS.BOLD_OFF);
             commands.push(...this.ESC_POS.LINE_FEED);
-            commands.push(...this.stringToBytes(this.formatTotalLine('Running Total:', sessionSummary.running_total)));
+            commands.push(...this.stringToBytes(this.formatTotalLine('Running Total:', sessionSummary.running_total || 0)));
             commands.push(...this.ESC_POS.LINE_FEED, ...this.ESC_POS.LINE_FEED);
 
             // Cash summary
-            commands.push(...this.stringToBytes(this.formatTotalLine('Expected Cash:', sessionSummary.expected_cash)));
+            commands.push(...this.stringToBytes(this.formatTotalLine('Beginning Cash:', sessionSummary.beginning_cash || 0)));
             commands.push(...this.ESC_POS.LINE_FEED);
-            commands.push(...this.stringToBytes(this.formatTotalLine('Cash Denomination:', sessionSummary.cash_denomination)));
-            commands.push(...this.ESC_POS.LINE_FEED, ...this.ESC_POS.LINE_FEED);
+            commands.push(...this.stringToBytes(this.formatTotalLine('Closing Cash:', sessionSummary.closing_cash || 0)));
+            commands.push(...this.ESC_POS.LINE_FEED);
+            commands.push(...this.stringToBytes(this.formatTotalLine('Cash Denomination:', sessionSummary.cash_denomination || 0)));
+            commands.push(...this.ESC_POS.LINE_FEED);
+
+            // Cash denomination details
+            if (sessionSummary.cash_denomination_details) {
+                commands.push(...this.stringToBytes('Cash Breakdown:'));
+                commands.push(...this.ESC_POS.LINE_FEED);
+                Object.entries(sessionSummary.cash_denomination_details).forEach(([denom, count]) => {
+                    const numDenom = parseFloat(denom);
+                    const numCount = count as number;
+                    if (numCount > 0) {
+                        const line = `${this.formatNumberWithComma(numDenom.toFixed(2))} x ${numCount} = ${this.formatNumberWithComma((numDenom * numCount).toFixed(2))}`;
+                        commands.push(...this.stringToBytes(`  ${line}`));
+                        commands.push(...this.ESC_POS.LINE_FEED);
+                    }
+                });
+                commands.push(...this.ESC_POS.LINE_FEED);
+            }
 
             // End marker
             commands.push(...this.ESC_POS.ALIGN_CENTER);


### PR DESCRIPTION
- Renamed `cash_denomination` to `cash_denomination_details` in the database and updated related models and services.
- Enhanced `getSessionSummary` method to include additional session details such as `beginning_cash` and `closing_cash`.
- Updated Vue components to reflect changes in session summary display, including a new modal for session summaries.
- Improved error handling and user feedback in session management processes.